### PR TITLE
feat: Integrate general tools into existing categories

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,70 @@
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background-color: #f4f7f9;
+    color: #333;
+    margin: 0;
+    padding: 20px;
+}
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+}
+h1 {
+    text-align: center;
+    color: #1a2a4d;
+    border-bottom: 2px solid #eef2f5;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+}
+.tool {
+    margin-bottom: 40px;
+    padding: 20px;
+    border: 1px solid #eef2f5;
+    border-radius: 6px;
+}
+h2 {
+    color: #0056b3;
+    margin-top: 0;
+    border-bottom: 1px solid #eef2f5;
+    padding-bottom: 8px;
+}
+textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 1rem;
+    min-height: 150px;
+    resize: vertical;
+}
+button {
+    padding: 8px 15px;
+    font-size: 0.9rem;
+    border: 1px solid #007bff;
+    background-color: #007bff;
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-right: 5px;
+    margin-top: 5px;
+    transition: background-color 0.2s;
+}
+button:hover {
+    background-color: #0056b3;
+}
+a.home-link {
+    display: block;
+    text-align: center;
+    margin-top: 20px;
+    color: #007bff;
+    text-decoration: none;
+    font-weight: bold;
+}
+a.home-link:hover {
+    text-decoration: underline;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -12,19 +12,30 @@ const toolsData = {
         tools: [
             { id: 'dieline-library', title: '盒型刀线模板库', description: '提供常用盒型标准刀线图下载，极大降低结构设计门槛。', styleType: 'tertiary', href: '#' },
             { id: 'barcode-generator', title: '条码/二维码生成器', description: '一键生成符合印刷标准的条形码或二维码矢量图。', styleType: 'secondary', href: '/tools/barcode-generator.html' },
+            { id: 'qrcode-generator', title: '二维码生成器', description: '根据文本或链接生成二维码。', styleType: 'secondary', href: '/tools/qrcode-generator.html' },
             { id: 'color-converter', title: '色彩模式转换器', description: '在RGB、CMYK和PANTONE色值之间进行快速查询和转换。', styleType: 'secondary', href: '#' },
             { id: 'unit-converter', title: '单位换算工具', description: '覆盖长度、重量、克重等包装行业常用单位的快速互换。', styleType: 'secondary', href: '#' },
+            { id: 'unit-converter-general', title: '通用单位换算器', description: '在各种通用单位之间进行转换。', styleType: 'secondary', href: '/tools/unit-converter.html' },
             { id: 'line-length-calculator', title: '线长计算器', description: '根据卷材外径、卷芯内径和材料厚度，计算卷材总长度。', styleType: 'secondary', href: '/tools/line-length-calculator.html' },
             { id: 'gsm-converter', title: '克重与厚度换算', description: '根据常见纸张类型，在克重(gsm)和厚度(mm)之间进行估算。', styleType: 'secondary', href: '/tools/gsm-converter.html' },
             { id: 'copy-generator', title: '包装文案灵感生成器', description: '为您的包装寻找一句话灵感。', styleType: 'tertiary', href: '/tools/copy-generator.html' },
+            { id: 'word-counter', title: '字数统计', description: '统计文本的字符数和单词数。', styleType: 'tertiary', href: '/tools/word-counter.html' },
+            { id: 'case-converter', title: '大小写转换', description: '一键转换文本的大小写格式。', styleType: 'tertiary', href: '/tools/case-converter.html' },
+            { id: 'text-diff', title: '文本对比工具', description: '高亮显示两段文本之间的差异。', styleType: 'tertiary', href: '/tools/text-diff.html' },
             { id: 'delta-e-explainer', title: '颜色差异(ΔE)解释器', description: '直观地理解Delta E数值在印刷颜色管理中的实际意义。', styleType: 'tertiary', href: '/tools/delta-e-explainer.html' },
+            { id: 'json-formatter', title: 'JSON 格式化', description: '美化和校验 JSON 数据。', styleType: 'tertiary', href: '/tools/json-formatter.html' },
+            { id: 'url-encoder', title: 'URL 编码/解码', description: '编码或解码 URL 中的特殊字符。', styleType: 'tertiary', href: '/tools/url-encoder.html' },
+            { id: 'base64-encoder', title: 'Base64 编码/解码', description: '对文本进行 Base64 编码或解码。', styleType: 'tertiary', href: '/tools/base64-encoder.html' },
+            { id: 'timezone-converter', title: '时区转换器', description: '在不同时区之间转换时间。', styleType: 'tertiary', href: '/tools/timezone-converter.html' },
         ]
     },
     prepressAids: {
         title: '印前处理辅助',
         tools: [
             { id: 'dpi-calculator', title: '分辨率 (DPI) 计算器', description: '检查图像是否达到300 DPI印刷标准，避免后期返工。', styleType: 'tertiary', href: '#' },
-            { id: 'pdf-checklist', title: 'PDF 印前检查清单', description: '交互式清单引导您规避常见印刷错误，减少沟通成本。', styleType: 'tertiary', href: '/tools/compliance-checklist.html' }
+            { id: 'pdf-checklist', title: 'PDF 印前检查清单', description: '交互式清单引导您规避常见印刷错误，减少沟通成本。', styleType: 'tertiary', href: '/tools/compliance-checklist.html' },
+            { id: 'image-converter', title: '图片格式转换', description: '转换图片的格式，如 PNG, JPG, WebP。', styleType: 'tertiary', href: '/tools/image-converter.html' },
+            { id: 'image-cropper', title: '图片缩放与裁剪', description: '可视化地裁剪和缩放图片。', styleType: 'tertiary', href: '/tools/image-cropper.html' },
         ]
     },
     warehousingLogistics: {

--- a/tools/base64-encoder.html
+++ b/tools/base64-encoder.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Base64 编码/解码 - 在线工具集</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <div class="container">
+        <div class="tool" id="base64-encoder-tool">
+            <h2>11. Base64 编码/解码 (Base64 Encoder/Decoder)</h2>
+            <p>用于文本与 Base64 格式之间的相互转换，支持 UTF-8 字符。</p>
+            <textarea id="base64-input" placeholder="输入字符串..." style="min-height: 100px;"></textarea>
+            <div style="margin-top: 10px;">
+                <button id="btn-base64-encode">编码 (Encode)</button>
+                <button id="btn-base64-decode">解码 (Decode)</button>
+            </div>
+            <textarea id="base64-output" readonly placeholder="结果..." style="margin-top: 10px; min-height: 100px; background-color: #e9ecef;"></textarea>
+        </div>
+        <a href="../index.html" class="home-link">返回主菜单</a>
+    </div>
+
+    <script>
+        const base64Input = document.getElementById('base64-input');
+        const base64Output = document.getElementById('base64-output');
+        const btnBase64Encode = document.getElementById('btn-base64-encode');
+        const btnBase64Decode = document.getElementById('btn-base64-decode');
+
+        btnBase64Encode.addEventListener('click', () => {
+            try {
+                // Modern, robust way to handle UTF-8 for btoa
+                const utf8Bytes = new TextEncoder().encode(base64Input.value);
+                const binaryString = Array.from(utf8Bytes).map(byte => String.fromCharCode(byte)).join('');
+                base64Output.value = btoa(binaryString);
+            } catch (e) {
+                 base64Output.value = '编码失败: ' + e.message;
+            }
+        });
+
+        btnBase64Decode.addEventListener('click', () => {
+            try {
+                // Modern, robust way to handle UTF-8 for atob
+                const binaryString = atob(base64Input.value);
+                const len = binaryString.length;
+                const bytes = new Uint8Array(len);
+                for (let i = 0; i < len; i++) {
+                    bytes[i] = binaryString.charCodeAt(i);
+                }
+                base64Output.value = new TextDecoder().decode(bytes);
+            } catch (e) {
+                base64Output.value = '解码失败: ' + e.message;
+                alert('解码失败：输入的字符串可能不是有效的 Base64 编码。');
+            }
+        });
+    </script>
+</body>
+</html>

--- a/tools/case-converter.html
+++ b/tools/case-converter.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>大小写转换 - 在线工具集</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <div class="container">
+        <div class="tool" id="case-converter-tool">
+            <h2>2. 大小写转换 (Case Converter)</h2>
+            <textarea id="case-converter-input" placeholder="在这里粘贴或输入文本..."></textarea>
+            <div class="controls" style="margin-top: 10px;">
+                <button id="btn-uppercase">转换为大写 (UPPERCASE)</button>
+                <button id="btn-lowercase">转换为小写 (lowercase)</button>
+                <button id="btn-sentencecase">句首大写 (Sentence case)</button>
+                <button id="btn-titlecase">标题大写 (Title Case)</button>
+            </div>
+        </div>
+        <a href="../index.html" class="home-link">返回主菜单</a>
+    </div>
+
+    <script>
+        const caseConverterInput = document.getElementById('case-converter-input');
+
+        document.getElementById('btn-uppercase').addEventListener('click', () => {
+            caseConverterInput.value = caseConverterInput.value.toUpperCase();
+        });
+        document.getElementById('btn-lowercase').addEventListener('click', () => {
+            caseConverterInput.value = caseConverterInput.value.toLowerCase();
+        });
+        document.getElementById('btn-sentencecase').addEventListener('click', () => {
+            const text = caseConverterInput.value.toLowerCase();
+            if (text.length > 0) {
+                caseConverterInput.value = text.replace(/(^\s*\w|[.!?]\s*\w)/g, c => c.toUpperCase());
+            }
+        });
+        document.getElementById('btn-titlecase').addEventListener('click', () => {
+            const text = caseConverterInput.value.toLowerCase();
+            caseConverterInput.value = text.replace(/\b\w/g, c => c.toUpperCase());
+        });
+    </script>
+</body>
+</html>

--- a/tools/image-converter.html
+++ b/tools/image-converter.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>图片格式转换 - 在线工具集</title>
+    <link rel="stylesheet" href="../css/style.css">
+    <style>
+        a.download-link {
+            display: inline-block; padding: 8px 15px; font-size: 0.9rem;
+            border: 1px solid #28a745; background-color: #28a745;
+            color: white; border-radius: 4px; text-decoration: none;
+            margin-top: 5px; transition: background-color 0.2s;
+        }
+        a.download-link:hover { background-color: #218838; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="tool" id="image-converter-tool">
+            <h2>6. 图片格式转换 (Image Converter)</h2>
+            <p>选择一个图片文件，然后选择您想要转换的目标格式。</p>
+            <input type="file" id="image-converter-input" accept="image/*">
+            <label for="image-format-select" style="margin-left: 10px;">转换为:</label>
+            <select id="image-format-select">
+                <option value="image/png">PNG</option>
+                <option value="image/jpeg">JPEG</option>
+                <option value="image/webp">WebP</option>
+            </select>
+            <button id="btn-convert-image" style="margin-left: 10px;">转换图片</button>
+            <div id="image-converter-output" style="margin-top: 20px; font-weight: bold;"></div>
+        </div>
+        <a href="../index.html" class="home-link">返回主菜单</a>
+    </div>
+
+    <script>
+        const btnConvertImage = document.getElementById('btn-convert-image');
+        btnConvertImage.addEventListener('click', () => {
+            const fileInput = document.getElementById('image-converter-input');
+            const formatSelect = document.getElementById('image-format-select');
+            const outputDiv = document.getElementById('image-converter-output');
+            outputDiv.innerHTML = '';
+
+            if (fileInput.files.length === 0) {
+                alert('请先选择一个图片文件！');
+                return;
+            }
+
+            const file = fileInput.files[0];
+            const selectedFormat = formatSelect.value;
+            const reader = new FileReader();
+
+            reader.onload = function(e) {
+                const img = new Image();
+                img.onload = function() {
+                    const canvas = document.createElement('canvas');
+                    canvas.width = img.width;
+                    canvas.height = img.height;
+                    const ctx = canvas.getContext('2d');
+
+                    if (selectedFormat === 'image/jpeg') {
+                        ctx.fillStyle = '#FFFFFF';
+                        ctx.fillRect(0, 0, canvas.width, canvas.height);
+                    }
+                    ctx.drawImage(img, 0, 0);
+
+                    try {
+                        const dataUrl = canvas.toDataURL(selectedFormat, 0.95);
+                        const extension = selectedFormat.split('/')[1];
+                        const originalFilename = file.name.substring(0, file.name.lastIndexOf('.'));
+                        const newFilename = `${originalFilename}_converted.${extension}`;
+                        outputDiv.innerHTML = `<p>转换成功！</p><a href="${dataUrl}" download="${newFilename}" class="download-link">下载 ${newFilename}</a>`;
+                    } catch (err) {
+                         outputDiv.innerHTML = `<p style="color: red;">转换失败: ${err.message}</p>`;
+                    }
+                }
+                img.onerror = function() {
+                    outputDiv.innerHTML = `<p style="color: red;">无法加载图片文件，请确保文件格式正确。</p>`;
+                }
+                img.src = e.target.result;
+            }
+            reader.onerror = function() {
+                 outputDiv.innerHTML = `<p style="color: red;">读取文件时发生错误。</p>`;
+            }
+            reader.readAsDataURL(file);
+        });
+    </script>
+</body>
+</html>

--- a/tools/image-cropper.html
+++ b/tools/image-cropper.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>图片缩放与裁剪 - 在线工具集</title>
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.13/cropper.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.13/cropper.min.js"></script>
+    <style>
+        a.download-link {
+            display: inline-block; padding: 8px 15px; font-size: 0.9rem;
+            border: 1px solid #28a745; background-color: #28a745;
+            color: white; border-radius: 4px; text-decoration: none;
+            margin-top: 5px; transition: background-color 0.2s;
+        }
+        a.download-link:hover { background-color: #218838; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="tool" id="image-cropper-tool">
+            <h2>7. 图片缩放与裁剪 (Image Resizer & Cropper)</h2>
+            <p>上传图片后，拖动选框进行裁剪，或在下方输入尺寸后应用并下载。</p>
+            <input type="file" id="cropper-input" accept="image/*">
+            <div id="cropper-container" style="margin-top: 15px;">
+                <img id="cropper-image" style="display: none; max-width: 100%;">
+            </div>
+            <div id="cropper-controls" style="display: none; margin-top: 15px;">
+                <label for="resize-width">宽度 (px):</label>
+                <input type="number" id="resize-width" placeholder="可选">
+                <label for="resize-height" style="margin-left: 10px;">高度 (px):</label>
+                <input type="number" id="resize-height" placeholder="可选">
+                <button id="btn-crop-download" style="margin-left: 10px;">应用并下载</button>
+            </div>
+            <div id="cropper-output" style="margin-top: 20px;"></div>
+        </div>
+        <a href="../index.html" class="home-link">返回主菜单</a>
+    </div>
+
+    <script>
+        const cropperInput = document.getElementById('cropper-input');
+        const cropperImage = document.getElementById('cropper-image');
+        const cropperControls = document.getElementById('cropper-controls');
+        const cropperOutput = document.getElementById('cropper-output');
+        const btnCropDownload = document.getElementById('btn-crop-download');
+        let cropper = null;
+
+        cropperInput.addEventListener('change', (e) => {
+            const files = e.target.files;
+            if (files && files.length > 0) {
+                const reader = new FileReader();
+                reader.onload = (event) => {
+                    cropperImage.src = event.target.result;
+                    cropperImage.style.display = 'block';
+                    cropperControls.style.display = 'block';
+                    cropperOutput.innerHTML = '';
+
+                    if (cropper) {
+                        cropper.destroy();
+                    }
+                    cropper = new Cropper(cropperImage, {
+                        viewMode: 1,
+                        background: false,
+                        responsive: true,
+                        autoCropArea: 0.8,
+                    });
+                };
+                reader.readAsDataURL(files[0]);
+            }
+        });
+
+        btnCropDownload.addEventListener('click', () => {
+            if (!cropper) {
+                alert('请先上传一张图片。');
+                return;
+            }
+            const resizeWidth = document.getElementById('resize-width').value;
+            const resizeHeight = document.getElementById('resize-height').value;
+
+            const canvasOptions = {};
+            if (resizeWidth) canvasOptions.width = parseInt(resizeWidth, 10);
+            if (resizeHeight) canvasOptions.height = parseInt(resizeHeight, 10);
+
+            const croppedCanvas = cropper.getCroppedCanvas(canvasOptions);
+
+            croppedCanvas.toBlob((blob) => {
+                const url = URL.createObjectURL(blob);
+                const originalFilename = cropperInput.files[0].name.substring(0, cropperInput.files[0].name.lastIndexOf('.'));
+                const newFilename = `${originalFilename}_cropped.png`;
+                cropperOutput.innerHTML = `<p>处理成功！</p><a href="${url}" download="${newFilename}" class="download-link">下载 ${newFilename}</a>`;
+            });
+        });
+    </script>
+</body>
+</html>

--- a/tools/json-formatter.html
+++ b/tools/json-formatter.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>JSON 格式化 - 在线工具集</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <div class="container">
+        <div class="tool" id="json-formatter-tool">
+            <h2>3. JSON 格式化与校验 (JSON Formatter)</h2>
+            <textarea id="json-input" placeholder="在此处粘贴您的 JSON 字符串..."></textarea>
+            <button id="btn-format-json" style="margin-top:10px;">格式化 JSON</button>
+            <div id="json-error" style="color: red; margin-top: 10px; font-weight: bold;"></div>
+            <pre style="background-color: #f8f9fa; border: 1px solid #dee2e6; padding: 15px; border-radius: 4px; white-space: pre-wrap; word-wrap: break-word; margin-top: 10px; min-height: 150px;"><code id="json-output"></code></pre>
+        </div>
+        <a href="../index.html" class="home-link">返回主菜单</a>
+    </div>
+
+    <script>
+        const jsonInput = document.getElementById('json-input');
+        const btnFormatJson = document.getElementById('btn-format-json');
+        const jsonOutput = document.getElementById('json-output');
+        const jsonError = document.getElementById('json-error');
+
+        btnFormatJson.addEventListener('click', () => {
+            jsonError.textContent = '';
+            jsonOutput.textContent = '';
+            const inputText = jsonInput.value.trim();
+            if (!inputText) {
+                jsonError.textContent = '输入不能为空。';
+                return;
+            }
+            try {
+                const jsonObj = JSON.parse(inputText);
+                jsonOutput.textContent = JSON.stringify(jsonObj, null, 2);
+            } catch (e) {
+                jsonError.textContent = 'JSON 格式无效: ' + e.message;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/tools/qrcode-generator.html
+++ b/tools/qrcode-generator.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>二维码生成器 - 在线工具集</title>
+    <link rel="stylesheet" href="../css/style.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+</head>
+<body>
+    <div class="container">
+        <div class="tool" id="qrcode-generator-tool">
+            <h2>5. 二维码生成器 (QR Code Generator)</h2>
+            <textarea id="qrcode-input" placeholder="输入文本或网址以生成二维码..." style="min-height: 80px;"></textarea>
+            <button id="btn-generate-qrcode" style="margin-top: 10px;">生成二维码</button>
+            <div id="qrcode-output" style="margin-top: 20px; padding: 10px; display: none; background: white; border: 1px solid #ddd;"></div>
+        </div>
+        <a href="../index.html" class="home-link">返回主菜单</a>
+    </div>
+
+    <script>
+        const btnGenerateQRCode = document.getElementById('btn-generate-qrcode');
+        const qrCodeOutput = document.getElementById('qrcode-output');
+        const qrCodeInput = document.getElementById('qrcode-input');
+        let qrcode = null;
+
+        btnGenerateQRCode.addEventListener('click', () => {
+            const text = qrCodeInput.value.trim();
+            if (!text) {
+                alert('请输入文本或网址！');
+                qrCodeInput.focus();
+                return;
+            }
+
+            qrCodeOutput.innerHTML = '';
+
+            try {
+                if (!qrcode) {
+                    qrcode = new QRCode(qrCodeOutput, {
+                        text: text,
+                        width: 150,
+                        height: 150,
+                        colorDark : "#000000",
+                        colorLight : "#ffffff",
+                        correctLevel : QRCode.CorrectLevel.H
+                    });
+                } else {
+                    qrcode.makeCode(text);
+                }
+                qrCodeOutput.style.display = 'inline-block';
+            } catch (e) {
+                alert("生成二维码时发生错误: " + e.message);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/tools/text-diff.html
+++ b/tools/text-diff.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>文本对比工具 - 在线工具集</title>
+    <link rel="stylesheet" href="../css/style.css">
+    <script src="https://cdn.jsdelivr.net/npm/diff-match-patch/diff_match_patch.js"></script>
+    <style>
+        .diff-container { display: flex; gap: 10px; }
+        .diff-container textarea { min-height: 250px; }
+        #diff-output { border: 1px solid #ccc; padding: 10px; min-height: 100px; border-radius: 4px; margin-top: 10px; line-height: 1.6; }
+        #diff-output del { background-color: #ffebe9; text-decoration: none; }
+        #diff-output ins { background-color: #e6ffed; text-decoration: none; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="tool" id="text-diff-tool">
+            <h2>4. 文本对比工具 (Text Diff Checker)</h2>
+            <div class="diff-container">
+                <textarea id="diff-input-1" placeholder="在此处粘贴原始文本..."></textarea>
+                <textarea id="diff-input-2" placeholder="在此处粘贴修改后的文本..."></textarea>
+            </div>
+            <button id="btn-run-diff" style="margin-top: 10px;">生成对比</button>
+            <h3 style="margin-bottom: 5px; margin-top: 20px;">对比结果:</h3>
+            <div id="diff-output"></div>
+        </div>
+        <a href="../index.html" class="home-link">返回主菜单</a>
+    </div>
+
+    <script>
+        const btnRunDiff = document.getElementById('btn-run-diff');
+        btnRunDiff.addEventListener('click', () => {
+            const text1 = document.getElementById('diff-input-1').value;
+            const text2 = document.getElementById('diff-input-2').value;
+            const diffOutput = document.getElementById('diff-output');
+
+            try {
+                const dmp = new diff_match_patch();
+                const diff = dmp.diff_main(text1, text2);
+                dmp.diff_cleanupSemantic(diff);
+
+                const display = dmp.diff_prettyHtml(diff);
+                diffOutput.innerHTML = display;
+            } catch (e) {
+                diffOutput.innerHTML = "生成对比时发生错误: " + e.message;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/tools/timezone-converter.html
+++ b/tools/timezone-converter.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>时区转换器 - 在线工具集</title>
+    <link rel="stylesheet" href="../css/style.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/luxon/3.4.4/luxon.min.js"></script>
+    <style>
+        .timezone-converter-io { display: flex; flex-direction: column; gap: 15px; margin-top: 15px; }
+        .timezone-group { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+        .timezone-group label { font-weight: bold; min-width: 130px; }
+        .timezone-group input, .timezone-group select { padding: 8px; font-size: 1rem; border-radius: 4px; border: 1px solid #ccc; }
+        #tz-output { font-size: 1.2rem; font-weight: bold; color: #0056b3; background-color: #f4f7f9; padding: 8px; border-radius: 4px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="tool" id="timezone-converter-tool">
+            <h2>9. 时区转换器 (Time Zone Converter)</h2>
+            <div class="timezone-converter-io">
+                <div class="timezone-group">
+                    <label for="tz-input-datetime">Source Time:</label>
+                    <input type="datetime-local" id="tz-input-datetime">
+                    <select id="tz-from"></select>
+                </div>
+                <div class="timezone-group">
+                    <label>Converted Time:</label>
+                    <span id="tz-output"></span>
+                </div>
+                <div class="timezone-group">
+                    <label for="tz-to">Target Timezone:</label>
+                    <select id="tz-to"></select>
+                </div>
+            </div>
+        </div>
+        <a href="../index.html" class="home-link">返回主菜单</a>
+    </div>
+
+    <script>
+        const tzInput = document.getElementById('tz-input-datetime');
+        const tzFromSelect = document.getElementById('tz-from');
+        const tzToSelect = document.getElementById('tz-to');
+        const tzOutput = document.getElementById('tz-output');
+        const DateTime = luxon.DateTime;
+
+        const commonTimezones = [
+            'UTC', 'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles',
+            'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Asia/Tokyo', 'Asia/Shanghai',
+            'Asia/Dubai', 'Australia/Sydney'
+        ];
+
+        function populateTimezones() {
+            commonTimezones.forEach(tz => {
+                tzFromSelect.innerHTML += `<option value="${tz}">${tz}</option>`;
+                tzToSelect.innerHTML += `<option value="${tz}">${tz}</option>`;
+            });
+            const localTimeZone = DateTime.local().zoneName;
+            if (commonTimezones.includes(localTimeZone)) {
+                tzFromSelect.value = localTimeZone;
+            } else {
+                // If local timezone is not in our common list, just default to first one.
+                tzFromSelect.value = commonTimezones[0];
+            }
+            tzToSelect.value = 'UTC';
+        }
+
+        function convertTimezone() {
+            if (!tzInput.value) return;
+
+            const fromZone = tzFromSelect.value;
+            const toZone = tzToSelect.value;
+
+            try {
+                const dt = DateTime.fromISO(tzInput.value, { zone: fromZone });
+                if (!dt.isValid) {
+                    tzOutput.textContent = 'Invalid Date/Time';
+                    return;
+                }
+                const convertedDt = dt.setZone(toZone);
+                tzOutput.textContent = convertedDt.toFormat("yyyy-LL-dd HH:mm:ss ZZZZ");
+            } catch (e) {
+                tzOutput.textContent = 'Error converting';
+            }
+        }
+
+        populateTimezones();
+        tzInput.value = DateTime.local().toFormat("yyyy-LL-dd'T'HH:mm");
+        convertTimezone();
+
+        tzInput.addEventListener('input', convertTimezone);
+        tzFromSelect.addEventListener('change', convertTimezone);
+        tzToSelect.addEventListener('change', convertTimezone);
+    </script>
+</body>
+</html>

--- a/tools/unit-converter.html
+++ b/tools/unit-converter.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>单位换算器 - 在线工具集</title>
+    <link rel="stylesheet" href="../css/style.css">
+    <style>
+        #unit-category { padding: 8px; font-size: 1rem; border-radius: 4px; border: 1px solid #ccc; }
+        .unit-converter-io { display: flex; align-items: center; gap: 15px; margin-top: 15px; flex-wrap: wrap; }
+        .unit-group { display: flex; flex-direction: column; gap: 5px; }
+        .unit-group input, .unit-group select { padding: 8px; font-size: 1rem; border-radius: 4px; border: 1px solid #ccc; }
+        .unit-converter-io span { font-size: 2rem; font-weight: bold; color: #555; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="tool" id="unit-converter-tool">
+            <h2>8. 单位换算器 (Unit Converter)</h2>
+            <div class="unit-converter-controls">
+                <select id="unit-category">
+                    <option value="length">长度 (Length)</option>
+                    <option value="weight">重量 (Weight)</option>
+                    <option value="temperature">温度 (Temperature)</option>
+                </select>
+            </div>
+            <div class="unit-converter-io">
+                <div class="unit-group">
+                    <label for="unit-input">From:</label>
+                    <input type="number" id="unit-input" value="1">
+                    <select id="unit-from"></select>
+                </div>
+                <span>=</span>
+                <div class="unit-group">
+                    <label for="unit-output">To:</label>
+                    <input type="number" id="unit-output" readonly>
+                    <select id="unit-to"></select>
+                </div>
+            </div>
+        </div>
+        <a href="../index.html" class="home-link">返回主菜单</a>
+    </div>
+
+    <script>
+        const unitCategory = document.getElementById('unit-category');
+        const unitFrom = document.getElementById('unit-from');
+        const unitTo = document.getElementById('unit-to');
+        const unitInput = document.getElementById('unit-input');
+        const unitOutput = document.getElementById('unit-output');
+
+        const conversions = {
+            length: { meter: 1, kilometer: 1000, centimeter: 0.01, millimeter: 0.001, mile: 1609.34, yard: 0.9144, foot: 0.3048, inch: 0.0254 },
+            weight: { kilogram: 1, gram: 0.001, milligram: 1e-6, pound: 0.453592, ounce: 0.0283495 },
+            temperature: { celsius: 'celsius', fahrenheit: 'fahrenheit', kelvin: 'kelvin' }
+        };
+
+        function populateUnits() {
+            const category = unitCategory.value;
+            const units = Object.keys(conversions[category]);
+            unitFrom.innerHTML = '';
+            unitTo.innerHTML = '';
+            units.forEach(unit => {
+                unitFrom.innerHTML += `<option value="${unit}">${unit}</option>`;
+                unitTo.innerHTML += `<option value="${unit}">${unit}</option>`;
+            });
+            if (units.length > 1) {
+                unitTo.value = units[1];
+            }
+            convertUnits();
+        }
+
+        function convertUnits() {
+            const category = unitCategory.value;
+            const from = unitFrom.value;
+            const to = unitTo.value;
+            const input = parseFloat(unitInput.value);
+
+            if (isNaN(input)) {
+                unitOutput.value = '';
+                return;
+            }
+
+            let result;
+            if (category === 'temperature') {
+                let tempInC;
+                if (from === 'celsius') tempInC = input;
+                else if (from === 'fahrenheit') tempInC = (input - 32) * 5 / 9;
+                else if (from === 'kelvin') tempInC = input - 273.15;
+
+                if (to === 'celsius') result = tempInC;
+                else if (to === 'fahrenheit') result = (tempInC * 9 / 5) + 32;
+                else if (to === 'kelvin') result = tempInC + 273.15;
+            } else {
+                const baseValue = input * conversions[category][from];
+                result = baseValue / conversions[category][to];
+            }
+
+            unitOutput.value = parseFloat(result.toFixed(6));
+        }
+
+        unitCategory.addEventListener('change', populateUnits);
+        unitFrom.addEventListener('change', convertUnits);
+        unitTo.addEventListener('change', convertUnits);
+        unitInput.addEventListener('input', convertUnits);
+
+        populateUnits();
+    </script>
+</body>
+</html>

--- a/tools/url-encoder.html
+++ b/tools/url-encoder.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>URL 编码/解码 - 在线工具集</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <div class="container">
+        <div class="tool" id="url-encoder-tool">
+            <h2>10. URL 编码/解码 (URL Encoder/Decoder)</h2>
+            <p>用于编码或解码 URL 中的特殊字符 (RFC3986)。</p>
+            <textarea id="url-input" placeholder="输入字符串..." style="min-height: 100px;"></textarea>
+            <div style="margin-top: 10px;">
+                <button id="btn-url-encode">编码 (Encode)</button>
+                <button id="btn-url-decode">解码 (Decode)</button>
+            </div>
+            <textarea id="url-output" readonly placeholder="结果..." style="margin-top: 10px; min-height: 100px; background-color: #e9ecef;"></textarea>
+        </div>
+        <a href="../index.html" class="home-link">返回主菜单</a>
+    </div>
+
+    <script>
+        const urlInput = document.getElementById('url-input');
+        const urlOutput = document.getElementById('url-output');
+        const btnUrlEncode = document.getElementById('btn-url-encode');
+        const btnUrlDecode = document.getElementById('btn-url-decode');
+
+        btnUrlEncode.addEventListener('click', () => {
+            urlOutput.value = encodeURIComponent(urlInput.value);
+        });
+
+        btnUrlDecode.addEventListener('click', () => {
+            try {
+                urlOutput.value = decodeURIComponent(urlInput.value);
+            } catch (e) {
+                urlOutput.value = '解码失败: ' + e.message;
+                alert('解码失败：输入的字符串可能不是有效的编码。');
+            }
+        });
+    </script>
+</body>
+</html>

--- a/tools/word-counter.html
+++ b/tools/word-counter.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>字数统计 - 在线工具集</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <div class="container">
+        <div class="tool" id="word-counter-tool">
+            <h2>1. 字数统计 (Character & Word Counter)</h2>
+            <textarea id="word-counter-input" placeholder="在这里粘贴或输入文本..."></textarea>
+            <div class="result" style="margin-top: 10px; font-weight: bold;">
+                <span>字符数: <span id="char-count">0</span></span> |
+                <span>单词数: <span id="word-count">0</span></span>
+            </div>
+        </div>
+        <a href="../index.html" class="home-link">返回主菜单</a>
+    </div>
+
+    <script>
+        const wordCounterInput = document.getElementById('word-counter-input');
+        const charCountSpan = document.getElementById('char-count');
+        const wordCountSpan = document.getElementById('word-count');
+
+        wordCounterInput.addEventListener('input', () => {
+            const text = wordCounterInput.value;
+
+            charCountSpan.textContent = text.length;
+
+            const words = text.trim().match(/\S+/g);
+            wordCountSpan.textContent = words ? words.length : 0;
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit fulfills the user's final request to integrate the 11 new general-purpose tools directly into the existing categories of the packaging toolkit homepage.

The changes include:
- Creating 11 new, self-contained general-purpose tool pages in the `tools/` directory.
- Creating a shared stylesheet for these new pages at `css/style.css`.
- Modifying the `toolsData` object in `js/main.js` to distribute the new tools among the existing categories (`designAids`, `prepressAids`, etc.).
- Reverting `js/app.js` to its original, generic rendering logic, which now correctly displays the expanded categories.
- This results in a single, unified `index.html` homepage that displays both old and new tools seamlessly.